### PR TITLE
feat: Add pdflatex API, Docker setup, CI, and README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
           -o output.pdf --fail http://localhost:8000/compile
           echo "Curl request sent."
 
+      - name: Output API logs on failure
+        if: failure()
+        run: |
+          echo "Curl request failed. Displaying API service logs:"
+          docker-compose logs api
+
       - name: Verify PDF output
         run: |
           if [ ! -f output.pdf ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@ FROM python:3.8-slim
 # Set the working directory in the container
 WORKDIR /app
 
+# Install Docker client
+# Using docker.io as it's generally available in Debian/Ubuntu repositories
+# Using --no-install-recommends to keep the image size down
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends docker.io && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy the dependencies file to the working directory
 COPY requirements.txt .
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# LaTeX Compilation Service
+
+This project provides a simple API service for compiling LaTeX documents into PDFs. It uses a FastAPI server and a pdflatex Docker image.
+
+## Overview
+
+The service consists of two main components orchestrated via `docker-compose.yml`:
+
+1.  **`api` service**: A Python FastAPI application that exposes an endpoint to receive LaTeX source code. It then uses the `pdflatex` service to compile the document.
+2.  **`pdflatex` service**: Runs the `cristiangreco/pdflatex` Docker image, which provides the TeX Live distribution.
+
+A GitHub Actions CI workflow is included in `.github/workflows/ci.yml` to automatically build the services and test the compilation endpoint on pull requests.
+
+## Prerequisites
+
+-   Docker
+-   Docker Compose
+
+## Getting Started
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository-url>
+    cd <repository-directory>
+    ```
+
+2.  **Build and run the services:**
+    ```bash
+    docker-compose up --build -d
+    ```
+    The API service will be available on `http://localhost:8000`.
+
+## API Usage
+
+### Compile LaTeX Document
+
+-   **Endpoint:** `/compile`
+-   **Method:** `POST`
+-   **Request Body:** JSON object with a `source` key containing the LaTeX document content.
+    ```json
+    {
+      "source": "\documentclass{article}\begin{document}Hello, world!\end{document}"
+    }
+    ```
+-   **Example with `curl`:**
+    ```bash
+    curl -X POST -H "Content-Type: application/json"     -d '{"source": "\documentclass{article}\begin{document}Hello from API!\end{document}"}'     -o output.pdf http://localhost:8000/compile
+    ```
+    This command will save the compiled PDF as `output.pdf`.
+
+-   **Success Response:**
+    -   Status Code: `200 OK`
+    -   Content-Type: `application/pdf`
+    -   Body: The compiled PDF document.
+
+-   **Error Response:**
+    -   Status Code: `400 Bad Request` (or other appropriate error codes)
+    -   Content-Type: `application/json`
+    -   Body: JSON object with an `error` key describing the issue.
+      ```json
+      {
+        "error": "LaTeX compilation failed",
+        "details": "<pdflatex command output>"
+      }
+      ```
+
+## Testing
+
+Unit tests for the API are located in `test_main.py` and can be run using `pytest` within the API container or a local environment with dependencies installed.
+
+The CI workflow also performs an integration test using `curl`.

--- a/main.py
+++ b/main.py
@@ -1,59 +1,105 @@
 import os
 import subprocess
 import uuid
+import logging # Added
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import FileResponse
-import uvicorn # Required for running the app with uvicorn
+from fastapi.responses import FileResponse, JSONResponse # JSONResponse Added
+import uvicorn
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 app = FastAPI()
 
 @app.post('/compile')
 async def compile_latex(request: Request):
+    unique_id = str(uuid.uuid4())
+    # Define base filename and paths (consistent with example, using unique_id as base)
+    base_filename = unique_id 
+    tex_filepath = f"{base_filename}.tex" # File will be created in current working directory
+    pdf_filepath = f"{base_filename}.pdf"
+    log_filepath = f"{base_filename}.log" # For pdflatex log
+    aux_filepath = f"{base_filename}.aux" # For pdflatex aux files
+
     try:
         data = await request.json()
         if not data or 'source' not in data:
+            logging.warning(f"Request {unique_id}: No source code provided.")
             raise HTTPException(status_code=400, detail='No source code provided')
 
         latex_source = data['source']
         
-        unique_id = str(uuid.uuid4())
-        tex_filename = f"{unique_id}.tex"
-        pdf_filename = f"{unique_id}.pdf"
-        log_filename = f"{unique_id}.log"
-        aux_filename = f"{unique_id}.aux"
-
         # Save LaTeX source to a .tex file
-        with open(tex_filename, 'w') as f:
+        with open(tex_filepath, 'w') as f:
             f.write(latex_source)
+        logging.info(f"Request {unique_id}: LaTeX source saved to {tex_filepath}")
 
         # Compile LaTeX using Docker
+        # The command mounts the current working directory (where tex_filepath is) to /workdir
+        # pdflatex reads from /workdir/tex_filename and outputs to /workdir/pdf_filename
         docker_command = [
             'docker', 'run', '--rm',
-            '-v', f'{os.getcwd()}:/workdir', # Mount current directory
+            '-v', f'{os.getcwd()}:/workdir', # Mount current directory as /workdir
             'cristiangreco/pdflatex',
-            'pdflatex', tex_filename
+            'pdflatex', 
+            '-interaction=nonstopmode', # Ensure it doesn't hang on errors
+            '-output-directory=/workdir', # Output PDF to /workdir
+            f'/workdir/{base_filename}.tex'    # Input tex file from /workdir
         ]
         
-        process = subprocess.run(docker_command, capture_output=True, text=True)
+        logging.info(f"Request {unique_id}: Executing Docker command: {' '.join(docker_command)}")
+        
+        # Using check=False to handle errors manually for better logging
+        process = subprocess.run(docker_command, capture_output=True, text=True, check=False)
 
-        if process.returncode == 0 and os.path.exists(pdf_filename):
-            return FileResponse(pdf_filename, media_type='application/pdf', filename=pdf_filename)
+        if process.stdout:
+            logging.info(f"Request {unique_id}: pdflatex stdout:\n{process.stdout}")
+        if process.stderr: # pdflatex often uses stderr for info/warnings too
+            logging.info(f"Request {unique_id}: pdflatex stderr:\n{process.stderr}")
+
+        if process.returncode == 0 and os.path.exists(pdf_filepath):
+            logging.info(f"Request {unique_id}: Compilation successful. PDF generated at {pdf_filepath}")
+            return FileResponse(pdf_filepath, media_type='application/pdf', filename=pdf_filepath)
         else:
-            error_message = process.stderr if process.stderr else 'Unknown compilation error'
-            if os.path.exists(log_filename):
-                with open(log_filename, 'r') as log_file:
-                    error_message += "\n\n--- Log File ---\n" + log_file.read()
-            raise HTTPException(status_code=500, detail=f"Compilation failed: {error_message}")
+            # Compilation failed or PDF not found
+            logging.error(f"Request {unique_id}: Compilation failed. Return code: {process.returncode}")
+            error_detail = process.stderr or process.stdout or "Unknown compilation error"
+            # Attempt to read the log file for more detailed errors if it exists
+            if os.path.exists(log_filepath):
+                with open(log_filepath, 'r') as log_file_content:
+                    error_detail += "\n\n--- LaTeX Log File ---\n" + log_file_content.read()
+            
+            # Use JSONResponse for structured error
+            return JSONResponse(
+                status_code=500, # Internal server error for compilation failure
+                content={'error': 'Compilation failed', 'details': error_detail}
+            )
 
-    except HTTPException:
-        raise # Re-raise HTTPException to ensure FastAPI handles it
+    except subprocess.CalledProcessError as e: # Should not be reached if check=False
+        logging.error(f"Request {unique_id}: pdflatex compilation failed with CalledProcessError.", exc_info=True)
+        logging.error(f"Command: {' '.join(e.cmd)}")
+        logging.error(f"Return code: {e.returncode}")
+        logging.error(f"stdout: {e.stdout}")
+        logging.error(f"stderr: {e.stderr}")
+        return JSONResponse(
+            status_code=500,
+            content={"error": "LaTeX compilation failed (CalledProcessError)", "details": e.stderr or e.stdout},
+        )
+    except HTTPException: # Re-raise HTTPException to ensure FastAPI handles it (like 400)
+        raise
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logging.error(f"Request {unique_id}: An unexpected error occurred: {str(e)}", exc_info=True)
+        return JSONResponse( # Use JSONResponse
+            status_code=500,
+            content={"error": "An internal server error occurred.", "details": str(e)},
+        )
     finally:
+        logging.info(f"Request {unique_id}: Cleaning up temporary files.")
         # Clean up temporary files
-        for filename in [tex_filename, pdf_filename, log_filename, aux_filename]:
+        for filename in [tex_filepath, pdf_filepath, log_filepath, aux_filepath]:
             if os.path.exists(filename):
                 os.remove(filename)
+                logging.info(f"Request {unique_id}: Removed {filename}")
 
 if __name__ == '__main__':
     uvicorn.run(app, host='0.0.0.0', port=5000)

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import os
 import subprocess
 import uuid
-import logging # Added
+import logging
+import shutil # Added
+from pathlib import Path # Added
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import FileResponse, JSONResponse # JSONResponse Added
+from fastapi.responses import FileResponse, JSONResponse
 import uvicorn
 
 # Configure logging
@@ -11,17 +13,33 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 
 app = FastAPI()
 
+TEMP_BASE_DIR = Path("/app/temp_files")
+
+# Create TEMP_BASE_DIR at startup if it doesn't exist. This is more efficient.
+TEMP_BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+
 @app.post('/compile')
 async def compile_latex(request: Request):
     unique_id = str(uuid.uuid4())
-    # Define base filename and paths (consistent with example, using unique_id as base)
-    base_filename = unique_id 
-    tex_filepath = f"{base_filename}.tex" # File will be created in current working directory
-    pdf_filepath = f"{base_filename}.pdf"
-    log_filepath = f"{base_filename}.log" # For pdflatex log
-    aux_filepath = f"{base_filename}.aux" # For pdflatex aux files
+    request_temp_dir = TEMP_BASE_DIR / unique_id
+    
+    # Fixed filenames within the unique temp dir
+    tex_filename = "document.tex"
+    pdf_filename = "document.pdf"
+    log_filename = "document.log" # For pdflatex log
+    # aux_filename = "document.aux" # Not explicitly used for cleanup list, but shutil.rmtree handles it
+
+    tex_file_path = request_temp_dir / tex_filename
+    pdf_file_path = request_temp_dir / pdf_filename
+    log_file_path = request_temp_dir / log_filename # For reading the log on error
 
     try:
+        # Ensure TEMP_BASE_DIR exists (redundant if created at startup, but harmless)
+        TEMP_BASE_DIR.mkdir(parents=True, exist_ok=True)
+        request_temp_dir.mkdir()
+        logging.info(f"Request {unique_id}: Created temporary directory {request_temp_dir}")
+
         data = await request.json()
         if not data or 'source' not in data:
             logging.warning(f"Request {unique_id}: No source code provided.")
@@ -29,77 +47,57 @@ async def compile_latex(request: Request):
 
         latex_source = data['source']
         
-        # Save LaTeX source to a .tex file
-        with open(tex_filepath, 'w') as f:
+        logging.info(f"Request {unique_id}: LaTeX source will be saved to {tex_file_path}")
+        with open(tex_file_path, 'w') as f:
             f.write(latex_source)
-        logging.info(f"Request {unique_id}: LaTeX source saved to {tex_filepath}")
 
-        # Compile LaTeX using Docker
-        # The command mounts the current working directory (where tex_filepath is) to /workdir
-        # pdflatex reads from /workdir/tex_filename and outputs to /workdir/pdf_filename
         docker_command = [
             'docker', 'run', '--rm',
-            '-v', f'{os.getcwd()}:/workdir', # Mount current directory as /workdir
+            '-v', f"{request_temp_dir.resolve()}:/workdir", # Mount unique dir
             'cristiangreco/pdflatex',
             'pdflatex', 
-            '-interaction=nonstopmode', # Ensure it doesn't hang on errors
-            '-output-directory=/workdir', # Output PDF to /workdir
-            f'/workdir/{base_filename}.tex'    # Input tex file from /workdir
+            '-interaction=nonstopmode',
+            '-output-directory=/workdir', # Output PDF in /workdir
+            tex_filename                  # Input .tex file (relative to /workdir)
         ]
         
         logging.info(f"Request {unique_id}: Executing Docker command: {' '.join(docker_command)}")
         
-        # Using check=False to handle errors manually for better logging
         process = subprocess.run(docker_command, capture_output=True, text=True, check=False)
 
         if process.stdout:
             logging.info(f"Request {unique_id}: pdflatex stdout:\n{process.stdout}")
-        if process.stderr: # pdflatex often uses stderr for info/warnings too
+        if process.stderr:
             logging.info(f"Request {unique_id}: pdflatex stderr:\n{process.stderr}")
 
-        if process.returncode == 0 and os.path.exists(pdf_filepath):
-            logging.info(f"Request {unique_id}: Compilation successful. PDF generated at {pdf_filepath}")
-            return FileResponse(pdf_filepath, media_type='application/pdf', filename=pdf_filepath)
+        if process.returncode == 0 and pdf_file_path.exists():
+            logging.info(f"Request {unique_id}: Compilation successful. PDF generated at {pdf_file_path}")
+            return FileResponse(pdf_file_path, media_type='application/pdf', filename=pdf_filename) # Return with fixed PDF name
         else:
-            # Compilation failed or PDF not found
             logging.error(f"Request {unique_id}: Compilation failed. Return code: {process.returncode}")
             error_detail = process.stderr or process.stdout or "Unknown compilation error"
-            # Attempt to read the log file for more detailed errors if it exists
-            if os.path.exists(log_filepath):
-                with open(log_filepath, 'r') as log_file_content:
+            if log_file_path.exists():
+                with open(log_file_path, 'r') as log_file_content:
                     error_detail += "\n\n--- LaTeX Log File ---\n" + log_file_content.read()
             
-            # Use JSONResponse for structured error
             return JSONResponse(
-                status_code=500, # Internal server error for compilation failure
+                status_code=500,
                 content={'error': 'Compilation failed', 'details': error_detail}
             )
 
-    except subprocess.CalledProcessError as e: # Should not be reached if check=False
-        logging.error(f"Request {unique_id}: pdflatex compilation failed with CalledProcessError.", exc_info=True)
-        logging.error(f"Command: {' '.join(e.cmd)}")
-        logging.error(f"Return code: {e.returncode}")
-        logging.error(f"stdout: {e.stdout}")
-        logging.error(f"stderr: {e.stderr}")
-        return JSONResponse(
-            status_code=500,
-            content={"error": "LaTeX compilation failed (CalledProcessError)", "details": e.stderr or e.stdout},
-        )
-    except HTTPException: # Re-raise HTTPException to ensure FastAPI handles it (like 400)
+    except HTTPException:
         raise
     except Exception as e:
         logging.error(f"Request {unique_id}: An unexpected error occurred: {str(e)}", exc_info=True)
-        return JSONResponse( # Use JSONResponse
+        return JSONResponse(
             status_code=500,
             content={"error": "An internal server error occurred.", "details": str(e)},
         )
     finally:
-        logging.info(f"Request {unique_id}: Cleaning up temporary files.")
-        # Clean up temporary files
-        for filename in [tex_filepath, pdf_filepath, log_filepath, aux_filepath]:
-            if os.path.exists(filename):
-                os.remove(filename)
-                logging.info(f"Request {unique_id}: Removed {filename}")
+        if request_temp_dir.exists():
+            logging.info(f"Request {unique_id}: Cleaning up temporary directory: {request_temp_dir}")
+            shutil.rmtree(request_temp_dir)
+            logging.info(f"Request {unique_id}: Removed {request_temp_dir}")
 
 if __name__ == '__main__':
     uvicorn.run(app, host='0.0.0.0', port=5000)


### PR DESCRIPTION
This commit includes the complete setup for the LaTeX compilation service:
- FastAPI application (`main.py`) providing a /compile endpoint.
- Dockerfile for containerizing the FastAPI application.
- docker-compose.yml for orchestrating the `api` and `pdflatex` services. Includes a healthcheck for the `api` service.
- requirements.txt listing Python dependencies (FastAPI, uvicorn, pytest, httpx).
- pytest tests (`test_main.py`) for the `/compile` endpoint.
- GitHub Actions CI workflow (`.github/workflows/ci.yml`) that builds the services, runs them, and tests the API using curl on pull requests.
- README.md providing an overview, setup instructions, and API usage details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a README file with setup instructions, API usage details, example requests, and information on testing and CI workflows for the LaTeX Compilation Service.
- **Bug Fixes**
  - Improved error reporting and logging for LaTeX compilation failures, providing detailed feedback and diagnostics.
- **Chores**
  - Enhanced CI workflow to output API service logs automatically on test failures for faster troubleshooting.
  - Updated Dockerfile to include Docker client installation within the container for improved tooling support.
- **Refactor**
  - Improved file management by isolating request files in unique temporary directories, enhancing cleanup and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->